### PR TITLE
Added a method to return the provided scope classpath JARs

### DIFF
--- a/src/main/java/rife/bld/BaseProject.java
+++ b/src/main/java/rife/bld/BaseProject.java
@@ -1404,6 +1404,22 @@ public class BaseProject extends BuildExecutor {
     }
 
     /**
+     * Returns all the jar files that are in the provided scope classpath.
+     *
+     * @since 1.7.6
+     */
+    public List<File> providedClasspathJars() {
+        // detect the jar files in the compile lib directory
+        var dir_abs = libCompileDirectory().getAbsoluteFile();
+        var jar_files = FileUtils.getFileList(dir_abs, INCLUDED_JARS, EXCLUDED_JARS);
+
+        // build the provided classpath
+        var classpath = new ArrayList<>(jar_files.stream().map(file -> new File(dir_abs, file)).toList());
+        addLocalDependencies(classpath, Scope.provided);
+        return classpath;
+    }
+
+    /**
      * Returns all the jar files that are in the runtime scope classpath.
      * <p>
      * By default, this collects all the jar files in the {@link #libRuntimeDirectory()}

--- a/src/main/java/rife/bld/BaseProject.java
+++ b/src/main/java/rife/bld/BaseProject.java
@@ -1409,12 +1409,8 @@ public class BaseProject extends BuildExecutor {
      * @since 1.7.6
      */
     public List<File> providedClasspathJars() {
-        // detect the jar files in the compile lib directory
-        var dir_abs = libCompileDirectory().getAbsoluteFile();
-        var jar_files = FileUtils.getFileList(dir_abs, INCLUDED_JARS, EXCLUDED_JARS);
-
         // build the provided classpath
-        var classpath = new ArrayList<>(jar_files.stream().map(file -> new File(dir_abs, file)).toList());
+        var classpath = new ArrayList<File>();
         addLocalDependencies(classpath, Scope.provided);
         return classpath;
     }

--- a/src/test/java/rife/bld/TestProject.java
+++ b/src/test/java/rife/bld/TestProject.java
@@ -106,6 +106,7 @@ public class TestProject {
         assertNotNull(project.mainSourceFiles());
         assertNotNull(project.testSourceFiles());
         assertNotNull(project.compileClasspathJars());
+        assertNotNull(project.providedClasspathJars());
         assertNotNull(project.runtimeClasspathJars());
         assertNotNull(project.standaloneClasspathJars());
         assertNotNull(project.testClasspathJars());

--- a/src/test/java/rife/bld/TestWebProject.java
+++ b/src/test/java/rife/bld/TestWebProject.java
@@ -96,6 +96,7 @@ public class TestWebProject {
         assertNotNull(project.mainSourceFiles());
         assertNotNull(project.testSourceFiles());
         assertNotNull(project.compileClasspathJars());
+        assertNotNull(project.providedClasspathJars());
         assertNotNull(project.runtimeClasspathJars());
         assertNotNull(project.standaloneClasspathJars());
         assertNotNull(project.testClasspathJars());


### PR DESCRIPTION
Needed for building Sprint Boot executable WARs (`WEB-INF/lib-provided`)