### PR TITLE
Use APIdia for JavaDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ bash -c "$(curl -fsSL https://rife2.com/bld/create.sh)"
 If you have any questions, suggestions, ideas or just want to chat, feel free
 to post on the [forums](https://forum.uwyn.com) or to join  us on [Discord](https://discord.gg/zDG6anEXQX).
 
-Read more in the [full documentation](https://github.com/rife2/bld/wiki) and [bld Javadocs](https://rife2.github.io/bld/).
+Read more in the [full documentation](https://github.com/rife2/bld/wiki) and [bld Javadocs](https://apidia.net/mvn/com.uwyn.rife2/bld/).
 
 # Building `bld`
 


### PR DESCRIPTION
[APIdia](https://apidia.net/) is a nice project making browsing JavaDoc more fun. APIdia added support for bld yesterday: https://github.com/APIdia-net/apidia.net/issues/11

Link to the most revent JavaDoc: https://apidia.net/mvn/com.uwyn.rife2/bld/2.2.1/

To make this documentation more discoverable, I took the liberty to propose to change the JavaDoc link.