### PR TITLE
Fixed missing main-class when running a modular application.

### DIFF
--- a/src/main/java/rife/bld/operations/RunOperation.java
+++ b/src/main/java/rife/bld/operations/RunOperation.java
@@ -42,16 +42,14 @@ public class RunOperation extends AbstractProcessOperation<RunOperation> {
             args.add(FileUtils.joinPaths(modulePath()));
         }
 
-        if (module() != null && !module().isEmpty()) {
-            args.add("-m");
-            args.add(module());
-        }
-        else if (mainClass() != null && !mainClass().isEmpty()){
-            args.add(mainClass());
+        if (mainClass() != null && !mainClass().isEmpty()) {
+            if (module() != null && !module().isEmpty()) {
+                args.add("-m");
+                args.add(module() + "/" + mainClass());
+            } else args.add(mainClass());
         }
 
         args.addAll(runOptions());
-
         return args;
     }
 


### PR DESCRIPTION
The `RunOperation` is using the java `-m` flag to run the modular application, but it did not provide the required main-class as of documentation `-m <module>[/<mainclass>] [args...]`.