### PR TITLE
Replace Maven Central with round-robin repos in dependencies tests

### DIFF
--- a/.github/workflows/bld.yml
+++ b/.github/workflows/bld.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        java-version: [ 17, 22, 24, 26 ]
+        java-version: [ 17, 21, 25, 26 ]
         include:
           - os: ubuntu-latest
             run-db-tests: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Publish
         run: >-
           ./bld publish
-          -Dbld.repo.github=https://maven.pkg.github.com/rife2/bld-antlr4
+          -Dbld.repo.github=https://maven.pkg.github.com/rife2/bld
           -Dbld.repo.github.username=${{ secrets.GH_USERNAME }}
           -Dbld.repo.github.password=${{ secrets.GH_PASSWORD }}      
           -Dbld.repo.rife2-snapshots=https://repo.rife2.com/snapshots/

--- a/src/test/java/rife/bld/TestProject.java
+++ b/src/test/java/rife/bld/TestProject.java
@@ -5,6 +5,8 @@
 package rife.bld;
 
 import org.junit.jupiter.api.Test;
+import rife.bld.dependencies.Repository;
+import rife.bld.dependencies.RepositoryTestHelper;
 import rife.bld.dependencies.VersionNumber;
 import rife.tools.FileUtils;
 
@@ -16,7 +18,6 @@ import java.nio.file.Files;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static rife.bld.dependencies.Repository.MAVEN_CENTRAL;
 import static rife.bld.dependencies.Scope.*;
 
 public class TestProject {
@@ -331,14 +332,17 @@ public class TestProject {
         }
     }
 
+
     static class CustomProjectAutoPurge extends Project {
+        static final List<Repository> repos = List.of(RepositoryTestHelper.getNextRepository());
+
         CustomProjectAutoPurge(File tmp) {
             workDirectory = tmp;
             pkg = "test.pkg";
             name = "my_project";
             version = new VersionNumber(0, 0, 1);
 
-            repositories = List.of(MAVEN_CENTRAL);
+            repositories = repos;
             scope(compile)
                 .include(dependency("com.uwyn.rife2", "rife2", version(1, 5, 11)));
             scope(test)

--- a/src/test/java/rife/bld/TestWebProject.java
+++ b/src/test/java/rife/bld/TestWebProject.java
@@ -5,6 +5,8 @@
 package rife.bld;
 
 import org.junit.jupiter.api.Test;
+import rife.bld.dependencies.Repository;
+import rife.bld.dependencies.RepositoryTestHelper;
 import rife.bld.dependencies.VersionNumber;
 import rife.tools.FileUtils;
 
@@ -13,7 +15,6 @@ import java.nio.file.Files;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static rife.bld.dependencies.Repository.MAVEN_CENTRAL;
 import static rife.bld.dependencies.Scope.*;
 import static rife.bld.dependencies.Scope.compile;
 
@@ -156,13 +157,15 @@ public class TestWebProject {
     }
 
     static class CustomWebProjectAutoPurge extends WebProject {
+        static final List<Repository> repos = List.of(RepositoryTestHelper.getNextRepository());
+
         CustomWebProjectAutoPurge(File tmp) {
             workDirectory = tmp;
             pkg = "test.pkg";
             name = "my_project";
             version = new VersionNumber(0, 0, 1);
 
-            repositories = List.of(MAVEN_CENTRAL);
+            repositories = repos;
             scope(compile)
                 .include(dependency("com.uwyn.rife2", "rife2", version(1, 5, 11)));
             scope(test)

--- a/src/test/java/rife/bld/dependencies/TestDependencySet.java
+++ b/src/test/java/rife/bld/dependencies/TestDependencySet.java
@@ -10,7 +10,6 @@ import rife.tools.StringUtils;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static rife.bld.dependencies.Repository.*;
 import static rife.bld.dependencies.RepositoryTestHelper.getNextRepository;
 import static rife.bld.dependencies.Scope.compile;
 import static rife.bld.dependencies.Scope.runtime;
@@ -372,6 +371,6 @@ public class TestDependencySet {
                │     └─ com.squareup.okio:okio-jvm:3.6.0
                ├─ com.squareup.okhttp3:logging-interceptor:4.12.0
                └─ org.json:json:20250107
-            """), dependencies.generateTransitiveDependencyTree(VersionResolution.dummy(), ArtifactRetriever.instance(), List.of(MAVEN_CENTRAL, SONATYPE_SNAPSHOTS), compile, runtime));
+            """), dependencies.generateTransitiveDependencyTree(VersionResolution.dummy(), ArtifactRetriever.instance(), RepositoryTestHelper.getNextRepositories(), compile, runtime));
     }
 }

--- a/src/test/java/rife/bld/operations/TestDependencyTreeOperation.java
+++ b/src/test/java/rife/bld/operations/TestDependencyTreeOperation.java
@@ -70,7 +70,7 @@ public class TestDependencyTreeOperation {
         var tmp = Files.createTempDirectory("test").toFile();
         try {
             var operation = new DependencyTreeOperation()
-                .repositories(List.of(Repository.MAVEN_CENTRAL));
+                .repositories(RepositoryTestHelper.getNextRepositories(1));
             operation.dependencies().scope(Scope.compile)
                 .include(new Dependency("com.uwyn.rife2", "rife2", new VersionNumber(1,5,20)))
                 .include(new Module("com.stripe", "stripe-java", new VersionNumber(20,136,0)))
@@ -143,7 +143,7 @@ public class TestDependencyTreeOperation {
         var tmp = Files.createTempDirectory("test").toFile();
         try {
             var operation = new DependencyTreeOperation()
-                .repositories(List.of(Repository.MAVEN_CENTRAL));
+                .repositories(RepositoryTestHelper.getNextRepositories(1));
             operation.dependencies().scope(Scope.provided)
                 .include(new Dependency("org.jsoup", "jsoup", new VersionNumber(1,16,1)))
                 .include(new Dependency("jakarta.servlet", "jakarta.servlet-api", new VersionNumber(5,0,0)))
@@ -222,7 +222,7 @@ public class TestDependencyTreeOperation {
         try {
             var project = new TestProject(tmp);
             project.createProjectStructure();
-            project.repositories().add(Repository.MAVEN_CENTRAL);
+            project.repositories().add(RepositoryTestHelper.getNextRepository());
             project.dependencies().scope(Scope.compile)
                 .include(new Dependency("com.uwyn.rife2", "rife2", new VersionNumber(1,5,20)))
                 .include(new Dependency("com.stripe", "stripe-java", new VersionNumber(20,136,0)))
@@ -299,7 +299,7 @@ public class TestDependencyTreeOperation {
         try {
             var project = new TestProject(tmp);
             project.createProjectStructure();
-            project.repositories().add(Repository.MAVEN_CENTRAL);
+            project.repositories().add(RepositoryTestHelper.getNextRepository());
             project.dependencies().scope(Scope.provided)
                 .include(new Dependency("org.jsoup", "jsoup", new VersionNumber(1,16,1)))
                 .include(new Dependency("jakarta.servlet", "jakarta.servlet-api", new VersionNumber(5,0,0)))
@@ -386,7 +386,7 @@ public class TestDependencyTreeOperation {
                 bld.extension-tests=com.uwyn.rife2:bld-tests-badge:1.4.8""");
             FileUtils.writeString(properties, wrapper.wrapperPropertiesFile());
 
-            project.repositories().add(Repository.MAVEN_CENTRAL);
+            project.repositories().add(RepositoryTestHelper.getNextRepository());
             project.dependencies().scope(Scope.compile)
                 .include(new Dependency("com.uwyn.rife2", "rife2", new VersionNumber(1,5,20)))
                 .include(new Dependency("com.stripe", "stripe-java", new VersionNumber(20,136,0)))

--- a/src/test/java/rife/bld/operations/TestDownloadOperation.java
+++ b/src/test/java/rife/bld/operations/TestDownloadOperation.java
@@ -137,7 +137,7 @@ public class TestDownloadOperation {
             var dir10 = new File(dir5, "dir10");
 
             var operation = new DownloadOperation()
-                .repositories(List.of(Repository.MAVEN_CENTRAL))
+                .repositories(RepositoryTestHelper.getNextRepositories(1))
                 .libCompileDirectory(dir1)
                 .libProvidedDirectory(dir2)
                 .libRuntimeDirectory(dir3)
@@ -225,7 +225,7 @@ public class TestDownloadOperation {
             var dir10 = new File(dir5, "dir10");
 
             var operation = new DownloadOperation()
-                .repositories(List.of(Repository.MAVEN_CENTRAL))
+                .repositories(RepositoryTestHelper.getNextRepositories(1))
                 .libCompileDirectory(dir1)
                 .libProvidedDirectory(dir2)
                 .libRuntimeDirectory(dir3)
@@ -359,7 +359,7 @@ public class TestDownloadOperation {
         try {
             var project = new TestProject(tmp);
             project.createProjectStructure();
-            project.repositories().add(Repository.MAVEN_CENTRAL);
+            project.repositories().add(RepositoryTestHelper.getNextRepository());
             project.dependencies().scope(Scope.compile)
                 .include(new Dependency("org.apache.commons", "commons-lang3", new VersionNumber(3,12,0)))
                 .include(new Module("org.json", "json", new VersionNumber(20240303)).excludeSources());
@@ -467,7 +467,7 @@ public class TestDownloadOperation {
         try {
             var project = new TestProject(tmp);
             project.createProjectStructure();
-            project.repositories().add(Repository.MAVEN_CENTRAL);
+            project.repositories().add(RepositoryTestHelper.getNextRepository());
             project.dependencies().scope(Scope.compile)
                 .include(new Dependency("com.stripe", "stripe-java", new VersionNumber(20,136,0)));
             project.dependencies().scope(Scope.runtime)

--- a/src/test/java/rife/bld/operations/TestPurgeOperation.java
+++ b/src/test/java/rife/bld/operations/TestPurgeOperation.java
@@ -132,7 +132,7 @@ public class TestPurgeOperation {
             var dir10 = new File(dir5, "dir10");
 
             var operation_download1 = new DownloadOperation()
-                .repositories(List.of(Repository.MAVEN_CENTRAL))
+                .repositories(RepositoryTestHelper.getNextRepositories(1))
                 .libCompileDirectory(dir1)
                 .libProvidedDirectory(dir2)
                 .libRuntimeDirectory(dir3)
@@ -162,7 +162,7 @@ public class TestPurgeOperation {
             operation_download1.execute();
 
             var operation_download2 = new DownloadOperation()
-                .repositories(List.of(Repository.MAVEN_CENTRAL))
+                .repositories(RepositoryTestHelper.getNextRepositories(1))
                 .libCompileDirectory(dir1)
                 .libProvidedDirectory(dir2)
                 .libRuntimeDirectory(dir3)
@@ -254,7 +254,7 @@ public class TestPurgeOperation {
                 FileUtils.generateDirectoryListing(tmp));
 
             var operation_purge = new PurgeOperation()
-                .repositories(List.of(Repository.MAVEN_CENTRAL))
+                .repositories(RepositoryTestHelper.getNextRepositories(1))
                 .libCompileDirectory(dir1)
                 .libProvidedDirectory(dir2)
                 .libRuntimeDirectory(dir3)
@@ -342,7 +342,7 @@ public class TestPurgeOperation {
             var dir10 = new File(dir5, "dir10");
 
             var operation_download1 = new DownloadOperation()
-                .repositories(List.of(Repository.MAVEN_CENTRAL))
+                .repositories(RepositoryTestHelper.getNextRepositories(1))
                 .libCompileDirectory(dir1)
                 .libProvidedDirectory(dir2)
                 .libRuntimeDirectory(dir3)
@@ -374,7 +374,7 @@ public class TestPurgeOperation {
             operation_download1.execute();
 
             var operation_download2 = new DownloadOperation()
-                .repositories(List.of(Repository.MAVEN_CENTRAL))
+                .repositories(RepositoryTestHelper.getNextRepositories(1))
                 .libCompileDirectory(dir1)
                 .libProvidedDirectory(dir2)
                 .libRuntimeDirectory(dir3)
@@ -566,7 +566,7 @@ public class TestPurgeOperation {
                 FileUtils.generateDirectoryListing(tmp));
 
             var operation_purge = new PurgeOperation()
-                .repositories(List.of(Repository.MAVEN_CENTRAL))
+                .repositories(RepositoryTestHelper.getNextRepositories(1))
                 .libCompileDirectory(dir1)
                 .libProvidedDirectory(dir2)
                 .libRuntimeDirectory(dir3)
@@ -805,7 +805,7 @@ public class TestPurgeOperation {
         try {
             var project1 = new TestProject(tmp);
             project1.createProjectStructure();
-            project1.repositories().add(Repository.MAVEN_CENTRAL);
+            project1.repositories().add(RepositoryTestHelper.getNextRepository());
             project1.dependencies().scope(Scope.compile)
                 .include(new Dependency("org.apache.commons", "commons-lang3", new VersionNumber(3,1)))
                 .include(new Module("org.json", "json", new VersionNumber(20240205)));
@@ -824,7 +824,7 @@ public class TestPurgeOperation {
 
             var project2 = new TestProject(tmp);
             project2.createProjectStructure();
-            project2.repositories().add(Repository.MAVEN_CENTRAL);
+            project2.repositories().add(RepositoryTestHelper.getNextRepository());
             project2.dependencies().scope(Scope.compile)
                 .include(new Dependency("org.apache.commons", "commons-lang3", new VersionNumber(3,12,0)))
                 .include(new Module("org.json", "json", new VersionNumber(20240303)));

--- a/src/test/java/rife/bld/operations/TestUpdatesOperation.java
+++ b/src/test/java/rife/bld/operations/TestUpdatesOperation.java
@@ -62,7 +62,7 @@ public class TestUpdatesOperation {
         var tmp = Files.createTempDirectory("test").toFile();
         try {
             var operation = new UpdatesOperation()
-                .repositories(List.of(Repository.MAVEN_CENTRAL));
+                .repositories(RepositoryTestHelper.getNextRepositories(1));
             operation.dependencies().scope(Scope.compile)
                 .include(new Dependency("org.apache.commons", "commons-lang3", new VersionNumber(3, 10, 0)));
             operation.dependencies().scope(Scope.runtime)
@@ -121,7 +121,7 @@ public class TestUpdatesOperation {
         try {
             var project = new TestProject(tmp);
             project.createProjectStructure();
-            project.repositories().add(Repository.MAVEN_CENTRAL);
+            project.repositories().add(RepositoryTestHelper.getNextRepository());
             project.dependencies().scope(Scope.compile)
                 .include(new Dependency("org.apache.commons", "commons-lang3", new VersionNumber(3, 10, 0)));
             project.dependencies().scope(Scope.runtime)

--- a/src/test/java/rife/bld/wrapper/TestWrapperExtensionResolver.java
+++ b/src/test/java/rife/bld/wrapper/TestWrapperExtensionResolver.java
@@ -7,6 +7,7 @@ package rife.bld.wrapper;
 import org.junit.jupiter.api.Test;
 import rife.bld.BldCache;
 import rife.bld.BldVersion;
+import rife.bld.dependencies.RepositoryTestHelper;
 import rife.bld.dependencies.VersionResolution;
 import rife.tools.FileUtils;
 
@@ -15,7 +16,6 @@ import java.nio.file.Files;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static rife.bld.wrapper.Wrapper.MAVEN_CENTRAL;
 
 public class TestWrapperExtensionResolver {
     @Test
@@ -71,7 +71,7 @@ public class TestWrapperExtensionResolver {
 
             var resolver = new WrapperExtensionResolver(tmp1, tmp2,
                 new Properties(), new Properties(),
-                List.of(MAVEN_CENTRAL), List.of("org.antlr:antlr4:4.11.1"), false, false);
+                List.of(RepositoryTestHelper.getNextRepository().location()), List.of("org.antlr:antlr4:4.11.1"), false, false);
             resolver.updateExtensions();
 
             assertTrue(cache_file.exists());
@@ -116,7 +116,7 @@ public class TestWrapperExtensionResolver {
             properties.put(VersionResolution.PROPERTY_OVERRIDE_PREFIX, "org.antlr:antlr4:4.11.0");
             var resolver = new WrapperExtensionResolver(tmp1, tmp2,
                 properties, new Properties(),
-                List.of(MAVEN_CENTRAL), List.of("org.antlr:antlr4:4.11.1"), false, false);
+                List.of(RepositoryTestHelper.getNextRepository().location()), List.of("org.antlr:antlr4:4.11.1"), false, false);
             resolver.updateExtensions();
 
             assertTrue(cache_file.exists());
@@ -161,7 +161,7 @@ public class TestWrapperExtensionResolver {
             properties.put(VersionResolution.PROPERTY_OVERRIDE_PREFIX, "org.glassfish:javax.json:1.1.3");
             var resolver = new WrapperExtensionResolver(tmp1, tmp2,
                 properties, new Properties(),
-                List.of(MAVEN_CENTRAL), List.of("org.antlr:antlr4:4.11.1"), false, false);
+                List.of(RepositoryTestHelper.getNextRepository().location()), List.of("org.antlr:antlr4:4.11.1"), false, false);
             resolver.updateExtensions();
 
             assertTrue(cache_file.exists());
@@ -203,7 +203,7 @@ public class TestWrapperExtensionResolver {
                 bld-wrapper.jar
                 bld-wrapper.properties""", String.join("\n", files1));
 
-            var resolver = new WrapperExtensionResolver(tmp1, tmp2, new Properties(), new Properties(), List.of(MAVEN_CENTRAL), List.of("org.antlr:antlr4:4.11.1"), true, false);
+            var resolver = new WrapperExtensionResolver(tmp1, tmp2, new Properties(), new Properties(), List.of(RepositoryTestHelper.getNextRepository().location()), List.of("org.antlr:antlr4:4.11.1"), true, false);
             resolver.updateExtensions();
 
             assertTrue(cache_file.exists());
@@ -251,7 +251,7 @@ public class TestWrapperExtensionResolver {
                 bld-wrapper.jar
                 bld-wrapper.properties""", String.join("\n", files1));
 
-            var resolver = new WrapperExtensionResolver(tmp1, tmp2, new Properties(), new Properties(), List.of(MAVEN_CENTRAL), List.of("org.antlr:antlr4:4.11.1"), false, true);
+            var resolver = new WrapperExtensionResolver(tmp1, tmp2, new Properties(), new Properties(), List.of(RepositoryTestHelper.getNextRepository().location()), List.of("org.antlr:antlr4:4.11.1"), false, true);
             resolver.updateExtensions();
 
             assertTrue(cache_file.exists());
@@ -299,7 +299,7 @@ public class TestWrapperExtensionResolver {
                 bld-wrapper.jar
                 bld-wrapper.properties""", String.join("\n", files1));
 
-            var resolver = new WrapperExtensionResolver(tmp1, tmp2, new Properties(), new Properties(), List.of(MAVEN_CENTRAL), List.of("org.antlr:antlr4:4.11.1"), true, true);
+            var resolver = new WrapperExtensionResolver(tmp1, tmp2, new Properties(), new Properties(), List.of(RepositoryTestHelper.getNextRepository().location()), List.of("org.antlr:antlr4:4.11.1"), true, true);
             resolver.updateExtensions();
 
             assertTrue(cache_file.exists());
@@ -358,7 +358,7 @@ public class TestWrapperExtensionResolver {
             properties.put(VersionResolution.PROPERTY_OVERRIDE_PREFIX, "org.antlr:antlr4:4.11.0");
             var resolver = new WrapperExtensionResolver(tmp1, tmp2,
                 properties, new Properties(),
-                List.of(MAVEN_CENTRAL), List.of("org.antlr:antlr4:4.11.1"), true, true);
+                List.of(RepositoryTestHelper.getNextRepository().location()), List.of("org.antlr:antlr4:4.11.1"), true, true);
             resolver.updateExtensions();
 
             assertTrue(cache_file.exists());
@@ -414,7 +414,7 @@ public class TestWrapperExtensionResolver {
                 bld-wrapper.properties""", String.join("\n", files1));
 
             var properties = new File(tmp1, "local.properties");
-            FileUtils.writeString("bld.repo.testrepo=" + MAVEN_CENTRAL, properties);
+            FileUtils.writeString("bld.repo.testrepo=" + RepositoryTestHelper.getNextRepository().location(), properties);
 
             var resolver = new WrapperExtensionResolver(tmp1, tmp2, new Properties(), new Properties(), List.of("testrepo"), List.of("org.antlr:antlr4:4.11.1"), false, false);
             resolver.updateExtensions();
@@ -457,7 +457,7 @@ public class TestWrapperExtensionResolver {
                 bld-wrapper.jar
                 bld-wrapper.properties""", String.join("\n", files1));
 
-            var resolver = new WrapperExtensionResolver(tmp1, tmp2, new Properties(), new Properties(), List.of(MAVEN_CENTRAL), List.of("org.antlr:antlr4:4.11.1"), false, false);
+            var resolver = new WrapperExtensionResolver(tmp1, tmp2, new Properties(), new Properties(), List.of(RepositoryTestHelper.getNextRepository().location()), List.of("org.antlr:antlr4:4.11.1"), false, false);
             resolver.updateExtensions();
 
             assertTrue(cache_file.exists());
@@ -508,7 +508,7 @@ public class TestWrapperExtensionResolver {
                 bld-wrapper.jar
                 bld-wrapper.properties""", String.join("\n", files1));
 
-            var resolver = new WrapperExtensionResolver(tmp1, tmp2, new Properties(), new Properties(), List.of(MAVEN_CENTRAL), List.of("org.antlr:antlr4:4.11.1"), false, false);
+            var resolver = new WrapperExtensionResolver(tmp1, tmp2, new Properties(), new Properties(), List.of(RepositoryTestHelper.getNextRepository().location()), List.of("org.antlr:antlr4:4.11.1"), false, false);
             resolver.updateExtensions();
 
             assertTrue(cache_file.exists());
@@ -576,7 +576,7 @@ public class TestWrapperExtensionResolver {
                 bld-wrapper.jar
                 bld-wrapper.properties""", String.join("\n", files1));
 
-            var resolver = new WrapperExtensionResolver(tmp1, tmp2, new Properties(), new Properties(), List.of(MAVEN_CENTRAL), List.of("org.antlr:antlr4:4.11.1"), false, false);
+            var resolver = new WrapperExtensionResolver(tmp1, tmp2, new Properties(), new Properties(), List.of(RepositoryTestHelper.getNextRepository().location()), List.of("org.antlr:antlr4:4.11.1"), false, false);
             resolver.updateExtensions();
 
             assertTrue(cache_file.exists());
@@ -644,7 +644,7 @@ public class TestWrapperExtensionResolver {
                 bld-wrapper.jar
                 bld-wrapper.properties""", String.join("\n", files1));
 
-            var resolver1 = new WrapperExtensionResolver(tmp1, tmp2, new Properties(), new Properties(), List.of(MAVEN_CENTRAL), List.of("org.antlr:antlr4:4.11.1"), false, false);
+            var resolver1 = new WrapperExtensionResolver(tmp1, tmp2, new Properties(), new Properties(), List.of(RepositoryTestHelper.getNextRepository().location()), List.of("org.antlr:antlr4:4.11.1"), false, false);
             resolver1.updateExtensions();
 
             assertTrue(cache_file.exists());
@@ -663,7 +663,7 @@ public class TestWrapperExtensionResolver {
                 javax.json-1.1.4.jar
                 org.abego.treelayout.core-1.0.3.jar""", String.join("\n", files2));
 
-            var resolver2 = new WrapperExtensionResolver(tmp1, tmp2, new Properties(), new Properties(), List.of(MAVEN_CENTRAL), List.of("org.antlr:antlr4:4.11.1", "org.jsoup:jsoup:1.15.4"), false, false);
+            var resolver2 = new WrapperExtensionResolver(tmp1, tmp2, new Properties(), new Properties(), List.of(RepositoryTestHelper.getNextRepository().location()), List.of("org.antlr:antlr4:4.11.1", "org.jsoup:jsoup:1.15.4"), false, false);
             resolver2.updateExtensions();
             var files3 = FileUtils.getFileList(tmp2);
             assertEquals(11, files3.size());
@@ -703,7 +703,7 @@ public class TestWrapperExtensionResolver {
                 bld-wrapper.jar
                 bld-wrapper.properties""", String.join("\n", files1));
 
-            var resolver1 = new WrapperExtensionResolver(tmp1, tmp2, new Properties(), new Properties(), List.of(MAVEN_CENTRAL), List.of("org.antlr:antlr4:4.11.1", "org.jsoup:jsoup:1.15.4"), false, false);
+            var resolver1 = new WrapperExtensionResolver(tmp1, tmp2, new Properties(), new Properties(), List.of(RepositoryTestHelper.getNextRepository().location()), List.of("org.antlr:antlr4:4.11.1", "org.jsoup:jsoup:1.15.4"), false, false);
             resolver1.updateExtensions();
 
             assertTrue(cache_file.exists());
@@ -723,7 +723,7 @@ public class TestWrapperExtensionResolver {
                 jsoup-1.15.4.jar
                 org.abego.treelayout.core-1.0.3.jar""", String.join("\n", files2));
 
-            var resolver2 = new WrapperExtensionResolver(tmp1, tmp2, new Properties(), new Properties(), List.of(MAVEN_CENTRAL), List.of("org.jsoup:jsoup:1.15.4"), false, false);
+            var resolver2 = new WrapperExtensionResolver(tmp1, tmp2, new Properties(), new Properties(), List.of(RepositoryTestHelper.getNextRepository().location()), List.of("org.jsoup:jsoup:1.15.4"), false, false);
             resolver2.updateExtensions();
             var files3 = FileUtils.getFileList(tmp2);
             assertEquals(4, files3.size());
@@ -758,7 +758,7 @@ public class TestWrapperExtensionResolver {
 
             var resolver1 = new WrapperExtensionResolver(tmp1, tmp2,
                 new Properties(), new Properties(),
-                List.of(MAVEN_CENTRAL), List.of("org.antlr:antlr4:4.11.1"), false, false);
+                List.of(RepositoryTestHelper.getNextRepository().location()), List.of("org.antlr:antlr4:4.11.1"), false, false);
             resolver1.updateExtensions();
 
             assertTrue(cache_file.exists());
@@ -781,7 +781,7 @@ public class TestWrapperExtensionResolver {
             properties.put(VersionResolution.PROPERTY_OVERRIDE_PREFIX, "org.antlr:antlr4:4.11.0");
             var resolver2 = new WrapperExtensionResolver(tmp1, tmp2,
                 properties, new Properties(),
-                List.of(MAVEN_CENTRAL), List.of("org.antlr:antlr4:4.11.1"), false, false);
+                List.of(RepositoryTestHelper.getNextRepository().location()), List.of("org.antlr:antlr4:4.11.1"), false, false);
             resolver2.updateExtensions();
             var files3 = FileUtils.getFileList(tmp2);
             assertEquals(10, files3.size());


### PR DESCRIPTION
- Replace Maven Central with round-robin repos in dependencies tests
- Correct Java LTS versions in matrix
